### PR TITLE
Add missing attribute "default_locale" to manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -25,5 +25,6 @@
       "128": "icon128.png"
     },
     "default_title": "Open Grok.com"
-  }
+  },
+  "default_locale": "en"
 }


### PR DESCRIPTION
Add the missing attribute "default_locale" to manifest.json to fix the error preventing the extension from loading.